### PR TITLE
Update default version and env vars

### DIFF
--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -45,7 +45,7 @@ module "container_apps" {
   acr_username = module.foundations.acr_admin_username
   acr_password = module.foundations.acr_admin_password
 
-  dibbs_version = "7.0.0"
+  dibbs_version = "8.5.0"
 
   azure_storage_connection_string = module.foundations.azure_storage_connection_string
   azure_container_name            = module.foundations.azure_container_name

--- a/terraform/resources/aca/_var.tf
+++ b/terraform/resources/aca/_var.tf
@@ -144,3 +144,15 @@ variable "migration_secret" {
   type        = string
   default     = ""
 }
+
+variable "ecr_processing_timeout" {
+  type        = string
+  description = "Set processing timeout length in ms,if not set defaults to 900000ms (15min)"
+  default     = "900000"
+}
+
+variable "display_feedback_links" {
+  description = "Display email link and touchpoints survey, If not set they are disabled, default is set to false "
+  type        = string
+  default     = "false"
+}

--- a/terraform/resources/aca/locals.tf
+++ b/terraform/resources/aca/locals.tf
@@ -177,6 +177,20 @@ locals {
         {
           name  = "METADATA_DATABASE_MIGRATION_SECRET",
           value = data.azurerm_key_vault_secret.ecr_viewer_migration_secret.value
+        },
+        {
+
+          name = "ECR_PROCESSING_TIMEOUT",
+
+          value = var.ecr_processing_timeout
+
+        },
+        {
+
+          name = "DISPLAY_FEEDBACK_LINKS",
+
+          value = var.display_feedback_links
+
         }
       ]
 


### PR DESCRIPTION
## Related Issue

1. Added env variables: 
- ecr_processing_timeout
- display_feedback_links

2. Updated default version to 8.5.0


 
## Checklist for Primary Reviewer

### Infrastructure
- [X ] Consult the results of the `terraform-plan` job inside the "Terraform Checks" workflow run for this PR. Confirm that there are no unexpected changes!

## Cloud
- [X ] If there are changes that cannot be tested locally, this has been deployed to our Azure `dev` environment for verification.
